### PR TITLE
add basic token Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ If `true` it will send HTTP POST requests to a given url.
 
 The url where to send HTTP POST requests (default: `http://localhost`).
 
+`weblog.basicToken`
+
+A Basic authentication token to append to each HTTP request.
+
 ## Examples
 
 ### Example `started` event

--- a/plugins/nf-weblog/src/main/nextflow/trace/WebLogFactory.groovy
+++ b/plugins/nf-weblog/src/main/nextflow/trace/WebLogFactory.groovy
@@ -15,10 +15,11 @@ class WebLogFactory implements TraceObserverFactory {
     Collection<TraceObserver> create(Session session) {
         def isEnabled = session.config.navigate('weblog.enabled') as Boolean
         def url = session.config.navigate('weblog.url') as String
+        def basicToken = session.config.navigate('weblog.basicToken') as String
         def result = new ArrayList()
         if ( isEnabled ) {
             if ( !url ) url = WebLogObserver.DEF_URL
-            def observer = new WebLogObserver(url)
+            def observer = new WebLogObserver(url, basicToken)
             result << observer
         }
         return result

--- a/plugins/nf-weblog/src/main/nextflow/trace/WebLogObserver.groovy
+++ b/plugins/nf-weblog/src/main/nextflow/trace/WebLogObserver.groovy
@@ -84,16 +84,15 @@ class WebLogObserver implements TraceObserver{
     /**
      * Constructor that consumes a URL and creates
      * a basic HTTP client.
-     * @param url The target address for sending messages to
+     * @param url
+     * @param basicToken
      */
-
     WebLogObserver(String url, String basicToken) {
         this.endpoint = checkUrl(url)
         this.basicToken = checkBasicToken(basicToken)
         this.webLogAgent = new Agent<>(this)
         this.generator = createJsonGeneratorForPayloads()
     }
-
 
     /**
      * only for testing purpose -- do not use
@@ -119,13 +118,9 @@ class WebLogObserver implements TraceObserver{
     }
 
     /**
-     * Check the provided basicToken is a valid value. If a invalid i.e. not a base64 encoded value,
-     * the constructor will raise an exception.
+     * Check the provided basic token, and raise an exception if it is not.
      *
-     * The RegEx was taken and adapted from http://urlregex.com
-     *
-     * @param url String with target URL
-     * @return The requested url or the default url, if invalid
+     * @param basicToken
      */
     protected String checkBasicToken(String basicToken) {
         def pattern = /^[A-Za-z0-9+=]+$/

--- a/plugins/nf-weblog/src/test/nextflow/trace/WebLogObserverTest.groovy
+++ b/plugins/nf-weblog/src/test/nextflow/trace/WebLogObserverTest.groovy
@@ -31,17 +31,38 @@ class WebLogObserverTest extends Specification {
 
     def 'do not send messages on wrong formatted url'() {
 
+        String url = "localhost"
         when:
-        new WebLogObserver("localhost")
+        new WebLogObserver(url, null)
 
         then:
-        thrown(IllegalArgumentException)
+        IllegalArgumentException e = thrown(IllegalArgumentException)
+        e.message == "Only http and https are supported -- The given URL was: ${url}"
+    }
+
+    def 'do not send messages on wrong formatted url'() {
+
+        when:
+        new WebLogObserver("http://localhost", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==")
+
+        then:
+        IllegalArgumentException e = thrown(IllegalArgumentException)
+        e.message == "Invalid auth token provided."
+    }
+
+    def 'send messages when basicToken is null'() {
+
+        when:
+        new WebLogObserver("http://localhost", null)
+
+        then:
+        notThrown(IllegalArgumentException)
     }
 
     def 'send message on different workflow events' () {
 
         given:
-        WebLogObserver httpPostObserver0 = Spy(WebLogObserver, constructorArgs: ["http://localhost"])
+        WebLogObserver httpPostObserver0 = Spy(WebLogObserver, constructorArgs: ["http://localhost", null])
         WorkflowMetadata workflowMeta = Mock(WorkflowMetadata)
 
         def bindingStub = Mock(ScriptBinding){
@@ -103,7 +124,7 @@ class WebLogObserverTest extends Specification {
     def 'should validate URL' () {
         given:
         def observer = new WebLogObserver()
-        
+
         expect:
         observer.checkUrl('http://localhost') == 'http://localhost'
         observer.checkUrl('http://google.com') == 'http://google.com'

--- a/plugins/nf-weblog/src/test/nextflow/trace/WebLogObserverTest.groovy
+++ b/plugins/nf-weblog/src/test/nextflow/trace/WebLogObserverTest.groovy
@@ -36,21 +36,21 @@ class WebLogObserverTest extends Specification {
         new WebLogObserver(url, null)
 
         then:
-        IllegalArgumentException e = thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
         e.message == "Only http and https are supported -- The given URL was: ${url}"
     }
 
-    def 'do not send messages on wrong formatted url'() {
+    def 'do not send messages on wrong formatted basic token'() {
 
         when:
         new WebLogObserver("http://localhost", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==")
 
         then:
-        IllegalArgumentException e = thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
         e.message == "Invalid auth token provided."
     }
 
-    def 'send messages when basicToken is null'() {
+    def 'send messages when basic token is null'() {
 
         when:
         new WebLogObserver("http://localhost", null)


### PR DESCRIPTION
This functionality allows to specify `basicToken` as part of `weblog` configuration. The value will be used added to the `Authorization` header when an HTTP request is processed.