### PR TITLE
Don't need to base64-encode the username and passoword for basic auth.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The url where to send HTTP POST requests (default: `http://localhost`).
 
 `weblog.basicToken`
 
-A Basic authentication token to append to each HTTP request. It should be the Base64 encoding of the user ID and password joined by a single colon, for example with the Bash command `base64 <(echo USER:PASSWORD)`.
+A Basic authentication token to append to each HTTP request. It should be the user ID and password joined by a single colon, for example `USER:PASSWORD`.
 
 ## Examples
 

--- a/plugins/nf-weblog/src/main/nextflow/trace/WebLogObserver.groovy
+++ b/plugins/nf-weblog/src/main/nextflow/trace/WebLogObserver.groovy
@@ -123,11 +123,10 @@ class WebLogObserver implements TraceObserver {
      * @param basicToken
      */
     protected String checkBasicToken(String basicToken) {
-        def pattern = /^[A-Za-z0-9+=]+$/
-        if (basicToken == null || basicToken ==~ pattern) {
+        if (basicToken == null || basicToken.contains(':')) {
             return basicToken
         }
-        throw new IllegalArgumentException("Invalid auth token provided.")
+        throw new IllegalArgumentException("Invalid auth token provided - should be 'USERNAME:PASSWORD'.")
     }
 
     /**

--- a/plugins/nf-weblog/src/test/nextflow/trace/WebLogObserverTest.groovy
+++ b/plugins/nf-weblog/src/test/nextflow/trace/WebLogObserverTest.groovy
@@ -47,7 +47,7 @@ class WebLogObserverTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == "Invalid auth token provided."
+        e.message == "Invalid auth token provided - should be 'USERNAME:PASSWORD'."
     }
 
     def 'send messages when basic token is null'() {


### PR DESCRIPTION
The docs (README) suggests that the user should base64-encode their USERNAME:PASSWORD string passed in via weblog configuration. This encoding is unnecessary, and will break, becauase the encoding is already handled by the nextflow.util.SimpleHttpClient class:

https://github.com/nextflow-io/nextflow/blob/f5362a7b067173a29d684663df22bb48fbbf5659/modules/nextflow/src/main/groovy/nextflow/util/SimpleHttpClient.groovy#L133

```groovy
con.setRequestProperty("Authorization","Basic ${basicToken.bytes.encodeBase64()}")
```

If the user actually does base64-encode the USERNAME:PASSWORD, the final header will end up being double-encoded and break.

This PR changes the weblog README to _not_ recommend the first level of base64 encoding.

